### PR TITLE
resp.Size is a function

### DIFF
--- a/internal/updater.go
+++ b/internal/updater.go
@@ -135,7 +135,7 @@ Loop:
 			stat.Name = "downloadMissing"
 			stat.Message = fmt.Sprintf("Downloading %s", filename)
 			stat.Progress = fmt.Sprintf("%.2f%%", 100*resp.Progress())
-			stat.Size = fmt.Sprintf("%.2f", float64(resp.Size)/1000000)
+			stat.Size = fmt.Sprintf("%.2f", float64(resp.Size())/1000000)
 			statusCh <- stat
 
 		case <-resp.Done:


### PR DESCRIPTION
given the error:
```sh
mining@x2:/mining/burstcoin$ go get -u github.com/HeosSacer/Easy2Burst
# github.com/HeosSacer/Easy2Burst/internal
/home/mining/go/src/github.com/HeosSacer/Easy2Burst/internal/updater.go:138:43: cannot convert resp.Size (type func() int64) to type float64
```

i'm guessing resp.Size is a function now (and probably wasn't previously)

probably fixes #2 